### PR TITLE
Add README for Mali and Normal sensors

### DIFF
--- a/API/README.md
+++ b/API/README.md
@@ -1,0 +1,14 @@
+# API
+
+1. 基於信任值的回應
+   `rule.py`
+   - Input：POST `/policy`，JSON 包含 `ip`、`time_delta`
+   - Output：`action` (`forward` 或 `drop`)、`trust`、`p_value`【F:API/rule.py†L13-L53】
+   - Parameters：`EXPECTED_INTERVAL`、`P_SUCCESS_TH`、`P_TRUST_TH`、`TRUST_THRESHOLD`
+
+2. 前 25% 優先權回應
+   `pq.py`
+   - Input：POST `/policy`，JSON 包含 `ip`、`time_delta`
+   - Output：`action` (`high`、`low` 或 `drop`)、`trust`、`p_value`、`high_threshold` 等【F:API/pq.py†L103-L179】
+   - Parameters：與 `rule.py` 相同並新增 `TOP_PERCENT`
+   - Extra：提供 `/stats`、`/debug_heap`、`/reset` 端點以查詢與重置狀態【F:API/pq.py†L181-L255】

--- a/Mali_Sensor/README.md
+++ b/Mali_Sensor/README.md
@@ -1,0 +1,25 @@
+# Mali Sensor
+
+1. 產生封包到達間隔  
+   `time_in.py`
+   - Input：無
+   - Output：`delta_ip5.csv`，產生封包到達間隔【F:Mali_Sensor/time_in.py†L4-L15】
+   - Parameters：`lambda_rate`（到達率）、`total_messages`（封包數量）、`seed`（隨機種子）、`output_filename`
+
+2. 產生洪水攻擊間隔  
+   `flood.py`
+   - Input：無
+   - Output：`flood_intervals.csv` 或 `burst_flood_intervals.csv`，模擬洪水攻擊【F:Mali_Sensor/flood.py†L5-L91】
+   - Parameters：`rate_per_second`（速率）、`duration_seconds`（持續時間）、`output_filename`、`seed`、`mode`、`burst_config`【F:Mali_Sensor/flood.py†L93-L106】
+
+3. 合併正常流量與攻擊  
+   `merge.py`
+   - Input：正常流量CSV、Flood攻擊CSV、攻擊時間點
+   - Output：`merged_traffic.csv`，整合事件與統計資料【F:Mali_Sensor/merge.py†L31-L116】【F:Mali_Sensor/merge.py†L163-L174】
+   - Parameters：`normal`、`flood`、`attack-times`、`output`、`simple`
+
+4. 發送攻擊流量  
+   `sent.py`
+   - Input：CSV間隔檔案
+   - Output：無，依間隔發送MQTT訊息【F:Mali_Sensor/sent.py†L18-L106】
+   - Parameters：`csv`、`broker`、`port`、`topic`、`start`【F:Mali_Sensor/sent.py†L107-L133】

--- a/Normal_Sensor/README.md
+++ b/Normal_Sensor/README.md
@@ -1,0 +1,13 @@
+# Normal Sensor
+
+1. 產生封包到達間隔  
+   `time_in.py`
+   - Input：無
+   - Output：`delta_ip5.csv`，產生封包到達間隔【F:Normal_Sensor/time_in.py†L4-L15】
+   - Parameters：`lambda_rate`（到達率）、`total_messages`（封包數量）、`seed`（隨機種子）、`output_filename`
+
+2. 發送正常流量  
+   `sent.py`
+   - Input：CSV間隔檔案
+   - Output：無，依間隔發送MQTT訊息【F:Normal_Sensor/sent.py†L18-L106】
+   - Parameters：`csv`、`broker`、`port`、`topic`、`start`【F:Normal_Sensor/sent.py†L107-L133】


### PR DESCRIPTION
## Summary
- document Mali sensor scripts for interval generation, flood attack simulation, traffic merging, and MQTT sending
- document normal sensor scripts for interval generation and MQTT publishing
- document API scripts for rule-based and priority-queue policy responses

## Testing
- `python -m py_compile API/*.py Mali_Sensor/*.py Normal_Sensor/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2ad2cd3788320bdf8c96408380c48