### PR TITLE
docs: add overview README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# Thesis Prototype Overview
+
+此專案整合 MQTT 邊緣節點的雙 FIFO 轉發系統、政策 API、五個感測器模擬，以及後處理工具，用於評估攻擊情境下的優先權機制。
+
+## 目錄結構
+- `mqtt-edge_fifo/`：Mosquitto 插件與雙 FIFO 轉發器。
+- `API/`：政策 API，回傳 accept/reject 或 high/low/drop。
+- `Normal_Sensor/`、`Mali_Sensor/`：正常感測器與洪水攻擊感測器。
+- `Post_Process/`：整理日誌並產生圖表的腳本。
+
+## 操作步驟
+1. **編譯插件並建立隔離網路**
+   ```bash
+   cd mqtt-edge_fifo/plugin
+   make
+   cd ..
+   sudo ./setup_ip_isolation.sh
+   ```
+2. **啟動邊緣 broker（載入插件）**
+   ```bash
+   mosquitto -c mqtt-edge_fifo/config/mosquitto.conf
+   ```
+3. **編譯並啟動轉發器讀取 FIFO**
+   ```bash
+   cd mqtt-edge_fifo/forwarder
+   gcc -o dual_fifo_forwarder pq_forwarder.c -lpaho-mqtt3c -ljson-c -lpthread
+   sudo ip netns exec ns_forwarder ./dual_fifo_forwarder
+   ```
+4. **啟動政策 API**
+   ```bash
+   cd API
+   python pq.py        # 或 rule.py
+   ```
+5. **設定五個感測器發送訊息**
+   - 四個正常感測器：
+     ```bash
+     python Normal_Sensor/sent.py --start "YYYY-MM-DD HH:MM:SS"
+     ```
+   - 一個惡意感測器進行洪水攻擊：
+     ```bash
+     python Mali_Sensor/sent.py --csv flood_intervals.csv --start "YYYY-MM-DD HH:MM:SS"
+     ```
+   所有感測器需連到邊緣 broker（可透過 `--broker`、`--port` 調整）。
+6. **收集日誌**
+   - 插件：`mqtt-edge_fifo/logs/edge_plugin.csv`
+   - 轉發器：`mqtt-edge_fifo/logs/forwarder_performance.csv`
+7. **後處理並產生圖表**
+   ```bash
+   cd Post_Process
+   python merge_2.5.py    # 合併 CSV
+   python bar_chart.py    # 生成圖表
+   ```
+   結果會輸出到 `Post_Process/Result/`。
+
+## 備註
+- 啟動感測器前請確保 broker、轉發器與 API 均已啟動。
+- 依系統環境可能需要安裝 `libmosquitto-dev`、`libjson-c-dev` 等套件以編譯插件與轉發器。

--- a/mqtt-edge_fifo/README.md
+++ b/mqtt-edge_fifo/README.md
@@ -1,0 +1,43 @@
+# MQTT Edge FIFO
+
+此目錄提供以雙 FIFO 為核心的 MQTT 邊緣處理流程，將邊緣 broker 接收到的訊息依政策分級，透過獨立 namespace 的轉發器送往主 broker。
+
+## 組成
+
+- `plugin/`：Mosquitto v5 插件，採三階段管線設計；Stage 1 先記錄訊息時間戳，Stage 2 呼叫政策 API 後依結果寫入 `high_priority_queue.fifo` 或 `low_priority_queue.fifo`，Stage 3 外部轉發器讀取 FIFO 並發佈。
+- `forwarder/`：包含 `pq_forwarder.c`、`new_dual.c` 等程式，優先處理高優先序 FIFO，再處理低優先序 FIFO，並發布到主 broker `tcp://192.168.254.139:1884`。
+- `setup_ip_isolation.sh`：建立 `ns_forwarder` network namespace，配置 192.168.100.2 以隔離轉發器。
+- `config/mosquitto.conf`：範例設定，載入 `simple_edge_plugin.so` 插件。
+- `test_mqtt_connection.sh`：在 namespace 中檢查與主 broker 的連線與發佈功能。
+
+## 編譯插件
+
+```bash
+cd plugin
+make            # 產生 simple_edge_plugin.so
+```
+
+## 建立隔離網路環境
+
+```bash
+sudo ./setup_ip_isolation.sh
+```
+
+## 執行流程
+
+1. 使用 `config/mosquitto.conf` 啟動邊緣 Broker：
+   ```bash
+   mosquitto -c config/mosquitto.conf
+   ```
+2. 在 `forwarder` 內編譯並執行轉發器：
+   ```bash
+   gcc -o dual_fifo_forwarder forwarder/pq_forwarder.c -lpaho-mqtt3c -ljson-c -lpthread
+   sudo ip netns exec ns_forwarder ./dual_fifo_forwarder
+   ```
+   轉發器優先處理 `high_priority_queue.fifo` 再處理 `low_priority_queue.fifo`，成功轉發會記錄在 `logs/forwarder_performance.csv`。
+3. 可執行 `./test_mqtt_connection.sh` 驗證隔離 IP 的連線與發佈能力。
+
+## 日誌
+
+- 插件詳細記錄：`/home/jason/mqtt-edge/logs/edge_plugin.csv`
+- 轉發器效能：`/home/jason/mqtt-edge/logs/forwarder_performance.csv`


### PR DESCRIPTION
## Summary
- document top-level workflow for MQTT FIFO edge pipeline, API, sensors, and post-processing

## Testing
- `make test` (fails: No rule to make target 'test')
- `make` in `mqtt-edge_fifo/plugin` (fails: libmosquitto/json-c headers missing)


------
https://chatgpt.com/codex/tasks/task_e_68aa7b280838832094766a08827e14a7